### PR TITLE
Add support for changing the ESP-IDF target.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,33 @@ jobs:
         path: 'esp32-s2-hmi-devkit-1/examples/smart-panel'
 ```
 
+## How to specify the ESP-IDF build target
+
+By default ESP-IDF will build for the esp32, if you want to build for different
+ESP32 types use the following notation in the GitHub action:
+
+```
+    name: Build ${{ matrix.target }} firmware
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [esp32, esp32c3, esp32s2]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: build
+      uses: espressif/esp-idf-ci-action@latest
+      with:
+        target: ${{ matrix.target }}
+	      path: firmware
+```
+
+Note that the above uses parallel build jobs, each job will have a dedicated
+copy of the source code and build directory. If parallel jobs are not used and
+only one copy of source code and a single build directory is used, the build
+directory must be removed before invoking a build for a different ESP32 type
+otherwise the build may fail due to `idf.py set-target` reporting a failure.
+
 ## How to specify a custom version of ESP-IDF
 
 GitHub does not support the specification of the Docker image tag as a variable.

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ branding:
   color: red
   icon: wifi
 inputs:
+  target:
+    description: 'Defines the type of ESP32 to build for, supported types: esp32, esp32s2, esp32s3, esp32c3. When not specified the default is esp32.'
+    default: 'esp32'
   path:
     description: 'Relative path under $GITHUB_WORKSPACE to place the repository'
     default: ''
@@ -11,4 +14,4 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - ${{ inputs.path }}
+    - ${{ inputs.target }} ${{ inputs.path }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -e
 
-CODE_PATH="$1"
+TARGET="$1"
+CODE_PATH="$2"
 
 . $IDF_PATH/export.sh
 
 cd "${CODE_PATH}"
+
+idf.py set-target "${TARGET}"
 
 idf.py build


### PR DESCRIPTION
This PR adds the ability to call `idf.py set-target {target}` prior to `idf.py build` inside the docker container. This allows building a single project for multiple targets without custom commands in the GitHub action.

Replaced with: https://github.com/espressif/esp-idf-ci-action/pull/7