### PR TITLE
Branch release v4.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf:latest
+FROM espressif/idf:release-v4.4
 
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ List based on: https://hub.docker.com/r/espressif/idf/tags
 
 ```
 latest
+release-v4.4
 release-v4.3
 release-v4.2
 release-v4.1


### PR DESCRIPTION
Looks like espressif pushed a release-v4.4 to docker about a week ago. Updates to add v4.4 branch. I tested it successfully with latest arduino-esp32. I've never submitted a pull request before so I apologize if I did this incorrectly.