### PR TITLE
include whole project in docker container

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,5 +22,5 @@ runs:
   steps:
     - run: |
         export IDF_TARGET=$(echo "${{ inputs.target }}" | tr '[:upper:]' '[:lower:]' | tr -d '_-') 
-        docker run -t -e IDF_TARGET="${IDF_TARGET}" -v "${GITHUB_WORKSPACE}/${{ inputs.path }}:/app" -w=/app espressif/idf:${{ inputs.esp_idf_version }} idf.py build
+        docker run -t -e IDF_TARGET="${IDF_TARGET}" -v "${GITHUB_WORKSPACE}:/app" -w "/app/${{ inputs.path }}" espressif/idf:${{ inputs.esp_idf_version }} idf.py build
       shell: bash


### PR DESCRIPTION
This is a followup of https://github.com/espressif/esp-idf-ci-action/pull/10.

Instead of only mounting the `path` from the input in the container, this will mount the whole repository under `/app` inside the container and then `cd` inside the container before building it.

This fixes the issue of repos which contain multiple stand-alone projects, which rely on code outside the project itself, respectively. Usually to be found in projects which also maintain examples in subfolders. What if `esp32-s2-hmi-devkit-1/examples/smart-panel` (from the [README](https://github.com/jdoubleu/esp-idf-ci-action#usage)) relies on code e.g. in `esp32-s2-hmi-devkit-1/driver/...`.