### PR TITLE
Add support for specifying the target via the action yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
       uses: espressif/esp-idf-ci-action@main
       with:
         esp_idf_version: v4.4
-	esp_target: esp32s2
+        esp_target: esp32s2
         path: 'esp32-s2-hmi-devkit-1/examples/smart-panel'
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,7 @@ jobs:
       uses: espressif/esp-idf-ci-action@main
       with:
         esp_idf_version: v4.4
-        path: 'esp32-s2-hmi-devkit-1/examples/smart-panel'
-    - name: esp-idf build
-      uses: espressif/esp-idf-ci-action@main
-      with:
-        esp_idf_version: v4.4
-        esp_target: esp32s2
+        target: esp32s2
         path: 'esp32-s2-hmi-devkit-1/examples/smart-panel'
 ```
 
@@ -44,7 +39,7 @@ It must be one of the tags from Docker Hub: https://hub.docker.com/r/espressif/i
 
 More information about supported versions of ESP-IDF: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/versions.html#support-periods
 
-### `esp_target`
+### `target`
 
 Type of ESP32 to build for. Default value `esp32`.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ jobs:
       with:
         esp_idf_version: v4.4
         path: 'esp32-s2-hmi-devkit-1/examples/smart-panel'
+    - name: esp-idf build
+      uses: espressif/esp-idf-ci-action@main
+      with:
+        esp_idf_version: v4.4
+	esp_target: esp32s2
+        path: 'esp32-s2-hmi-devkit-1/examples/smart-panel'
 ```
 
 ## Parameters
@@ -37,3 +43,9 @@ The version of ESP-IDF for the action. Default value `latest`.
 It must be one of the tags from Docker Hub: https://hub.docker.com/r/espressif/idf/tags
 
 More information about supported versions of ESP-IDF: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/versions.html#support-periods
+
+### `esp_target`
+
+Type of ESP32 to build for. Default value `esp32`.
+
+The value must be one of the supported ESP-IDF targets as documented here: https://github.com/espressif/esp-idf#esp-idf-release-and-soc-compatibility

--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: docker run -t -e CONFIG_IDF_TARGET="${{ inputs.esp_target }}" -v "${GITHUB_WORKSPACE}/${{ inputs.path }}:/app" -w=/app espressif/idf:${{ inputs.esp_idf_version }} idf.py build
+    - run: docker run -t -e IDF_TARGET="${{ inputs.esp_target }}" -v "${GITHUB_WORKSPACE}/${{ inputs.path }}:/app" -w=/app espressif/idf:${{ inputs.esp_idf_version }} idf.py build
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: docker run -t -e IDF_TARGET="${{ inputs.target }}" -v "${GITHUB_WORKSPACE}/${{ inputs.path }}:/app" -w=/app espressif/idf:${{ inputs.esp_idf_version }} idf.py build
+    - run: |
+        export IDF_TARGET=$(echo "${{ inputs.target }}" | tr '[:upper:]' '[:lower:]' | tr -d '_-') 
+        docker run -t -e IDF_TARGET="${IDF_TARGET}" -v "${GITHUB_WORKSPACE}/${{ inputs.path }}:/app" -w=/app espressif/idf:${{ inputs.esp_idf_version }} idf.py build
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -12,9 +12,13 @@ inputs:
     description: 'Version of ESP-IDF docker image to use'
     default: 'latest'
     required: false
+  esp_target:
+    description: 'ESP32 variant to build for'
+    default: 'esp32'
+    required: false
 
 runs:
   using: "composite"
   steps:
-    - run: docker run -t -v "${GITHUB_WORKSPACE}/${{ inputs.path }}:/app" -w=/app espressif/idf:${{ inputs.esp_idf_version }} idf.py build
+    - run: docker run -t -e CONFIG_IDF_TARGET="${{ inputs.esp_target }}" -v "${GITHUB_WORKSPACE}/${{ inputs.path }}:/app" -w=/app espressif/idf:${{ inputs.esp_idf_version }} idf.py build
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: 'Version of ESP-IDF docker image to use'
     default: 'latest'
     required: false
-  esp_target:
+  target:
     description: 'ESP32 variant to build for'
     default: 'esp32'
     required: false
@@ -20,5 +20,5 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: docker run -t -e IDF_TARGET="${{ inputs.esp_target }}" -v "${GITHUB_WORKSPACE}/${{ inputs.path }}:/app" -w=/app espressif/idf:${{ inputs.esp_idf_version }} idf.py build
+    - run: docker run -t -e IDF_TARGET="${{ inputs.target }}" -v "${GITHUB_WORKSPACE}/${{ inputs.path }}:/app" -w=/app espressif/idf:${{ inputs.esp_idf_version }} idf.py build
       shell: bash


### PR DESCRIPTION
This PR adds a new parameter to the action yaml which is used for specifying the ESP-IDF target to be used for the build.

Example run with mixed usage of ESP32 and ESP32-S3: https://github.com/atanisoft/ESP32CommandStation/actions/runs/1922997306

Syntax:
```
    strategy:
      max-parallel: 3
      matrix:
        target:
          - esp32-v4.4-L298
          - esp32-v4.4-LMD18200
          - esp32-v4.4-BTS7960B
          - esp32-v4.4-PCB
          - esp32-latest-L298
          - esp32-latest-LMD18200
          - esp32-latest-BTS7960B
          - esp32-latest-PCB
          - esp32s3-latest-PCB
    steps:
      - uses: actions/checkout@v2
        with:
          submodules: recursive
          fetch-depth: 0
      - uses: jungwinter/split@v2
        id: target
        with:
          msg: ${{ matrix.target }}
          separator: '-'
      - name: Configure default pin mapping
        run: |
          echo "CONFIG_ESP32CS_${{ steps.target.outputs._2 }}=y" > sdkconfig
      - name: Build
        uses: atanisoft/esp-idf-ci-action@main
        with:
          esp_idf_version: ${{ steps.target.outputs._1 }}
          esp_target: ${{ steps.target.outputs._0 }}
```

Fixes: https://github.com/espressif/esp-idf-ci-action/issues/5

This PR replaces: https://github.com/espressif/esp-idf-ci-action/pull/7.