### PR TITLE
add new parameter 'action'

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Type of ESP32 to build for. Default value `esp32`.
 
 The value must be one of the supported ESP-IDF targets as documented here: https://github.com/espressif/esp-idf#esp-idf-release-and-soc-compatibility
 
-### `action`
+### `command`
 
 Optional: Specify the command that will run as part of this GitHub build step.
 
@@ -54,5 +54,5 @@ Default: `idf.py build`
 Overriding this is useful for running other commands via github actions. Example:
 
 ```yaml
-   action: esptool.py merge_bin -o ../your_final_output.bin @flash_args 
+   command: esptool.py merge_bin -o ../your_final_output.bin @flash_args
 ```

--- a/README.md
+++ b/README.md
@@ -44,3 +44,15 @@ More information about supported versions of ESP-IDF: https://docs.espressif.com
 Type of ESP32 to build for. Default value `esp32`.
 
 The value must be one of the supported ESP-IDF targets as documented here: https://github.com/espressif/esp-idf#esp-idf-release-and-soc-compatibility
+
+### `action`
+
+Optional: Specify the command that will run as part of this GitHub build step.
+
+Default: `idf.py build`
+
+Overriding this is useful for running other commands via github actions. Example:
+
+```yaml
+   action: esptool.py merge_bin -o ../your_final_output.bin @flash_args 
+```

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Espressif IoT Development Framework (ESP-IDF)"
-description: "This action build your firmware for ESP32 directly in GitHub using Espressif ESP-IDF Docker image."
+description: "This action builds your firmware for ESP32 directly in GitHub using Espressif ESP-IDF Docker image."
 branding:
   color: red
   icon: wifi
@@ -16,8 +16,8 @@ inputs:
     description: 'ESP32 variant to build for'
     default: 'esp32'
     required: false
-  action:
-    description: 'Action to run inside the docker container (default: builds the project)'
+  command:
+    description: 'Command to run inside the docker container (default: builds the project)'
     default: 'idf.py build'
     required: false
 
@@ -26,5 +26,5 @@ runs:
   steps:
     - run: |
         export IDF_TARGET=$(echo "${{ inputs.target }}" | tr '[:upper:]' '[:lower:]' | tr -d '_-') 
-        docker run -t -e IDF_TARGET="${IDF_TARGET}" -v "${GITHUB_WORKSPACE}:/app" -w "/app/${{ inputs.path }}" espressif/idf:${{ inputs.esp_idf_version }} ${{ inputs.action }}
+        docker run -t -e IDF_TARGET="${IDF_TARGET}" -v "${GITHUB_WORKSPACE}:/app" -w "/app/${{ inputs.path }}" espressif/idf:${{ inputs.esp_idf_version }} ${{ inputs.command }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -16,11 +16,15 @@ inputs:
     description: 'ESP32 variant to build for'
     default: 'esp32'
     required: false
+  action:
+    description: 'Action to run inside the docker container (default: builds the project)'
+    default: 'idf.py build'
+    required: false
 
 runs:
   using: "composite"
   steps:
     - run: |
         export IDF_TARGET=$(echo "${{ inputs.target }}" | tr '[:upper:]' '[:lower:]' | tr -d '_-') 
-        docker run -t -e IDF_TARGET="${IDF_TARGET}" -v "${GITHUB_WORKSPACE}:/app" -w "/app/${{ inputs.path }}" espressif/idf:${{ inputs.esp_idf_version }} idf.py build
+        docker run -t -e IDF_TARGET="${IDF_TARGET}" -v "${GITHUB_WORKSPACE}:/app" -w "/app/${{ inputs.path }}" espressif/idf:${{ inputs.esp_idf_version }} ${{ inputs.action }}
       shell: bash


### PR DESCRIPTION
- Allow specifying alternative commands to run other than `idf.py build`
- Useful for using other esp-idf tools inside the docker container as part of Github CI builds.
- Defaults to `idf.py build`
- fixes #2

Example: Building custom flash images as part of Github actions

```yaml
      - name: Create Final Merged Binary
        uses: espressif/esp-idf-ci-action
        with:
          esp_idf_version: v4.4
          path: './build/'

          # 'command' is the new thing this PR adds
          command: esptool.py --chip esp32 merge_bin --fill-flash-size 4MB -o ../your_custom_file.bin @flash_args
```

notes:
- Based on previous work by @BrianPugh
- I tested this with just my local projects, not sure if there's other test suites that it should be run through/etc
- Thanks everyone