### PR TITLE
Mount the Repository under its name instead of app (RDT-315)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ runs:
   steps:
     - run: |
         export IDF_TARGET=$(echo "${{ inputs.target }}" | tr '[:upper:]' '[:lower:]' | tr -d '_-') 
-        docker run -t -e IDF_TARGET="${IDF_TARGET}" -v "${GITHUB_WORKSPACE}:/${{ github.repository }}" -w "/${{ github.repository }}/${{ inputs.path }}" espressif/idf:${{ inputs.esp_idf_version }} ${{ inputs.command }}
+        docker run -t -e IDF_TARGET="${IDF_TARGET}" -v "${GITHUB_WORKSPACE}:/app/${{ github.repository }}" -w "/app/${{ github.repository }}/${{ inputs.path }}" espressif/idf:${{ inputs.esp_idf_version }} ${{ inputs.command }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ runs:
   steps:
     - run: |
         export IDF_TARGET=$(echo "${{ inputs.target }}" | tr '[:upper:]' '[:lower:]' | tr -d '_-') 
-        docker run -t -e IDF_TARGET="${IDF_TARGET}" -v "${GITHUB_WORKSPACE}:/app" -w "/app/${{ inputs.path }}" espressif/idf:${{ inputs.esp_idf_version }} ${{ inputs.command }}
+        docker run -t -e IDF_TARGET="${IDF_TARGET}" -v "${GITHUB_WORKSPACE}:/${{ github.repository }}" -w "/${{ github.repository }}/${{ inputs.path }}" espressif/idf:${{ inputs.esp_idf_version }} ${{ inputs.command }}
       shell: bash


### PR DESCRIPTION
I'm using this to build some examples in a component I'm developing
As per the developer documentation for the components, we should use a override_path in the idf_component.yml file for each example:
https://github.com/espressif/idf-component-manager/wiki#add-examples-to-the-component

The problem is that the base path is mounted as "app" and not the component name, so when idf was trying to resolve dependencies it was failing.

This change, mounts the code under the repository name instead of app, and this idf can resolve it using the path_override. 

(maybe a better option would be to provide a config option to specify the path the repository is mounted under in the docker image?)
