### PR TITLE
Feature/signing secret (RDT-349)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,62 @@ Overriding this is useful for running other commands via github actions. Example
 ```yaml
 command: esptool.py merge_bin -o ../your_final_output.bin @flash_args
 ```
+
+### `signing_secret`
+
+Optional: Specify the GitHub Actions Secret in order to sign the built binary by using the `espsecure.py` command.
+
+This is useful for using GitHub Actions to generate a signed binary on a [workflow dispatch event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) and obtaining signed images with a couple of clicks. Also, by using this method you do not need to share private keys among developers since it will be stored as en encrypted secret.
+
+The following example assumes that you have a GitHub Action Secret named `MY_SIGNING_KEY` and you have a `scripts` folder containing the bash scripts described below. Also, the public key that complements the private key in `MY_SIGNING_KEY` should be stored under `public/verification_key.pem`. Check [Generating Secure Boot Signing Key](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/security/secure-boot-v1.html#generating-secure-boot-signing-key) to see how to generate a private key and [Remote Signing of Images](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/security/secure-boot-v1.html#remote-signing-of-images) to understand how to extract the public key.
+
+TLDR: private key generation and public key extraction commands:
+```bash
+mkdir ~/my-project-private-stuff
+
+cd ~/my-project-private-stuff
+
+espsecure.py generate_signing_key --version 2 signing_key.pem
+
+espsecure.py extract_public_key --version 2 --keyfile signing_key.pem verification_key.pem
+```
+Remember to move the `verification_key.pem` to `your-repository/public/verification_key.pem` and add `signing_key.pem` as a GitHub Actions Secret.
+
+The following yaml code should be placed after your build step.
+```yaml
+- name: Sign binary
+  env:
+    SIGN_KEY: ${{secrets.MY_SIGNING_KEY}}
+  uses: espressif/esp-idf-ci-action@v1
+  with:
+    esp_idf_version: v4.4.2
+    target: esp32s3
+    signing_secret: "$SIGN_KEY"
+    command: scripts/sign_binary.sh
+- name: Verify binary signature
+  uses: espressif/esp-idf-ci-action@v1
+  with:
+    esp_idf_version: v4.4.2
+    target: esp32s3
+    command: scripts/verify_binary.sh
+- name: Publish artifact
+  uses: actions/upload-artifact@v3
+  with:
+    name: my-project-signed
+    path: ./build/my-project-signed.bin
+```
+Contents of `scripts/sign_binary.sh`:
+```bash
+#!/bin/bash
+set -eu
+echo "$SIGNING_SECRET" | espsecure.py sign_data --version 2 --keyfile /dev/stdin --output ./build/my-project-signed.bin ./build/my-project.bin
+```
+
+Contents of `scripts/verify_binary.sh`:
+```bash
+#!/bin/bash
+set -eu
+espsecure.py verify_signature --version 2 --keyfile public/verification_key.pem ./build/my-project-signed.bin
+```
+
+To trigger the workflow you should go to the `Actions` tab on your repository, find your workflow and click on the `Run workflow` button. After your workflow succeeds you should be able to download your signed binary as a `.zip` file.

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     default: 'idf.py build'
     required: false
   signing_secret:
-    description: 'GitHub Actions Secret passed to the docker container to sing the binary by using the espsecure command'
+    description: 'GitHub Actions Secret passed to the docker container to sing the binary by using the espsecure.py command'
     required: false
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -20,11 +20,14 @@ inputs:
     description: 'Command to run inside the docker container (default: builds the project)'
     default: 'idf.py build'
     required: false
+  signing_secret:
+    description: 'GitHub Actions Secret passed to the docker container to sing the binary by using the espsecure command'
+    required: false
 
 runs:
   using: "composite"
   steps:
     - run: |
         export IDF_TARGET=$(echo "${{ inputs.target }}" | tr '[:upper:]' '[:lower:]' | tr -d '_-') 
-        docker run -t -e IDF_TARGET="${IDF_TARGET}" -v "${GITHUB_WORKSPACE}:/app/${{ github.repository }}" -w "/app/${{ github.repository }}/${{ inputs.path }}" espressif/idf:${{ inputs.esp_idf_version }} ${{ inputs.command }}
+        docker run -t -e IDF_TARGET="${IDF_TARGET}" -e SIGNING_SECRET="${{ inputs.signing_secret }}" -v "${GITHUB_WORKSPACE}:/app/${{ github.repository }}" -w "/app/${{ github.repository }}/${{ inputs.path }}" espressif/idf:${{ inputs.esp_idf_version }} ${{ inputs.command }}
       shell: bash


### PR DESCRIPTION
This PR allows to use the `espsecure.py` command together with GitHub Actions Secrets to generate signed binaries without sharing private keys among developers.

I was not able to route my secret from my action to the docker container in the `esp-idf-ci-action` action. This PR allows to share the private key with the container without storing it in a file.

What do you think? I have tested it with the following action and it works: 

```yaml
name: Developer build

on:
  workflow_dispatch:

jobs:
  build:
    runs-on: ubuntu-latest
    steps:
    - name: Checkout repo
      uses: actions/checkout@v2
      with:
        submodules: 'recursive'
    - name: Build
      uses: StevenMacias/esp-idf-ci-action@feature/signing_secret
      with:
        esp_idf_version: v4.4.2
        target: esp32s3
    - name: Sign binary
      env:
        SIGN_KEY: ${{secrets.SIGNING_KEY}}
      uses: StevenMacias/esp-idf-ci-action@feature/signing_secret
      with:
        esp_idf_version: v4.4.2
        target: esp32s3
        signing_secret: "$SIGN_KEY"
        command: scripts/sign_binary.sh
    - name: Verify binary signature
      uses: StevenMacias/esp-idf-ci-action@feature/signing_secret
      with:
        esp_idf_version: v4.4.2
        target: esp32s3
        command: scripts/verify_binary.sh
    - name: Publish artifact
      uses: actions/upload-artifact@v3
      with:
        name: binary-signed
        path: ./build/binary-signed.bin
```

I have updated the README with relevant information on how to use the new `signing_secret` input.

Thank a lot for your work!