### PR TITLE
Add custom IDF Source option (RDT-770)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: "Version of ESP-IDF docker image to use"
     default: "latest"
     required: false
+  esp_idf_root:
+    description: "Docker Repository to obtain the ESP-IDF image from"
+    default: "espressif/idf"
+    required: false
   target:
     description: "ESP32 variant to build for"
     default: "esp32"
@@ -27,6 +31,6 @@ runs:
     - run: |
         export IDF_TARGET=$(echo "${{ inputs.target }}" | tr '[:upper:]' '[:lower:]' | tr -d '_-')
         docker run -t -e IDF_TARGET="${IDF_TARGET}" -v "${GITHUB_WORKSPACE}:/app/${{ github.repository }}" \
-        -w "/app/${{ github.repository }}/${{ inputs.path }}" espressif/idf:${{ inputs.esp_idf_version }} \
+        -w "/app/${{ github.repository }}/${{ inputs.path }}" ${{ inputs.esp_idf_root }}:${{ inputs.esp_idf_version }} \
         /bin/bash -c 'git config --global --add safe.directory "*" && ${{ inputs.command }}'
       shell: bash


### PR DESCRIPTION
## Info

Added option to not only use the default espressif-hosted IDF, but also use a custom root.

## Why?

Having a custom version of IDF with own hosted docker image making it impossible to use this action without modifications. With this, the action is still compatible with all current installations but adds an option to use custom root.
