### PR TITLE
Additional Args and configurable docker image source (RDT-971)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,26 @@ It must be one of the tags from Docker Hub: https://hub.docker.com/r/espressif/i
 
 More information about supported versions of ESP-IDF: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/versions.html#support-periods
 
+### `esp_idf_docker_image`
+
+The base image for the docker container to run. Default value `espressif/idf`
+
+If using a modified or self-hosted version of the IDF. The `esp_idf_version` will still be used to specify the tag of the docker image, so setting both can be used to directly specify which docker image to use.
+
+### `extra_docker_args`
+
+Additional parameters to pass to the docker run command. Default value is no additional command (empty).
+
+The argument is passed directly to the docke run command, just before the specification of the docker image.
+
+Can be used to add additional volumes and environment variables to the container, like having a ccache directory to speed up recompilation (needs ccache to be installed in the specified docker image and make sure to have ccache folder available on host device). Example:
+
+```yaml
+extra_docker_args: -v ./.ccache:/root/.ccache -e CCACHE_DIR=/root/.ccache
+```
+
+More information about parameters for docker run: https://docs.docker.com/reference/cli/docker/container/run/
+
 ### `target`
 
 Type of ESP32 to build for. Default value `esp32`.

--- a/action.yml
+++ b/action.yml
@@ -12,11 +12,11 @@ inputs:
     description: "Version of ESP-IDF docker image to use"
     default: "latest"
     required: false
-  esp_idf_root:
+  esp_idf_docker_image:
     description: "Docker Repository to obtain the ESP-IDF image from"
     default: "espressif/idf"
     required: false
-  additional_args:
+  extra_docker_args:
     description: "Additional arguments to pass to the docker run command"
     default: ""
     required: false
@@ -38,7 +38,7 @@ runs:
         -e IDF_TARGET="${IDF_TARGET}" \
         -v "${GITHUB_WORKSPACE}:/app/${{ github.repository }}" \
         -w "/app/${{ github.repository }}/${{ inputs.path }}" \
-        ${{ inputs.additional_args }} \
-        ${{ inputs.esp_idf_root }}:${{ inputs.esp_idf_version }} \
+        ${{ inputs.extra_docker_args }} \
+        ${{ inputs.esp_idf_docker_image }}:${{ inputs.esp_idf_version }} \
         /bin/bash -c 'git config --global --add safe.directory "*" && ${{ inputs.command }}'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: "Docker Repository to obtain the ESP-IDF image from"
     default: "espressif/idf"
     required: false
+  additional_args:
+    description: "Additional arguments to pass to the docker run command"
+    default: ""
+    required: false
   target:
     description: "ESP32 variant to build for"
     default: "esp32"
@@ -30,7 +34,11 @@ runs:
   steps:
     - run: |
         export IDF_TARGET=$(echo "${{ inputs.target }}" | tr '[:upper:]' '[:lower:]' | tr -d '_-')
-        docker run -t -e IDF_TARGET="${IDF_TARGET}" -v "${GITHUB_WORKSPACE}:/app/${{ github.repository }}" \
-        -w "/app/${{ github.repository }}/${{ inputs.path }}" ${{ inputs.esp_idf_root }}:${{ inputs.esp_idf_version }} \
+        docker run -t \
+        -e IDF_TARGET="${IDF_TARGET}" \
+        -v "${GITHUB_WORKSPACE}:/app/${{ github.repository }}" \
+        -w "/app/${{ github.repository }}/${{ inputs.path }}" \
+        ${{ inputs.additional_args }} \
+        ${{ inputs.esp_idf_root }}:${{ inputs.esp_idf_version }} \
         /bin/bash -c 'git config --global --add safe.directory "*" && ${{ inputs.command }}'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: "Version of ESP-IDF docker image to use"
     default: "latest"
     required: false
+  esp_idf_root:
+    description: "Docker Repository to obtain the ESP-IDF image from"
+    default: "espressif/idf"
+    required: false
   target:
     description: "ESP32 variant to build for"
     default: "esp32"
@@ -27,6 +31,6 @@ runs:
     - run: |
         export IDF_TARGET=$(echo "${{ inputs.target }}" | tr '[:upper:]' '[:lower:]' | tr -d '_-')
         docker run -t -e IDF_TARGET="${IDF_TARGET}" -v "${GITHUB_WORKSPACE}:/app/${{ github.repository }}" \
-        -w "/app/${{ github.repository }}/${{ inputs.path }}" espressif/idf:${{ inputs.esp_idf_version }} \
+        -w "/app/${{ github.repository }}/${{ inputs.path }}" ${{ inputs.esp_idf_root }}:${{ inputs.esp_idf_version }} \
         /bin/bash -c 'git config --global --add safe.directory "*" && ${{ inputs.command }}'
       shell: bash


### PR DESCRIPTION
## Configurable Docker image source

Added `esp_idf_root` to be used as source for the docker image. Can be used to select docker images hosted on different accounts or servers.

## Additional arguments

Added `additional_args` to add custom arguments to the docker run command. Can be used to enable ccache usage, only add ccache ci action and add the following lines:

    -v ./.ccache:/root/.ccache -e CCACHE_DIR=/root/.ccache

Only make sure the `.ccache` folder is created if no cache was already build (always on the first run).
